### PR TITLE
Upgrade halite

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ license: MIT
 dependencies:
   halite:
     github: icyleaf/halite
-    version: 0.10.1
+    version: 0.10.7
 development_dependencies:
   webmock:
     github: manastech/webmock.cr


### PR DESCRIPTION
Fixes #2 

and removes the warning `Shard "halite" version (0.10.0) doesn't match tag version (0.10.1)` when running `shards install`

<img width="501" alt="Capture d’écran 2020-12-22 à 00 51 05" src="https://user-images.githubusercontent.com/20380692/102832901-fa44f500-43ef-11eb-839e-7fbd5a6b43e8.png">